### PR TITLE
GH-54: Fix exception type for validation error in formSystem()

### DIFF
--- a/src/methods/FornbergMC.cpp
+++ b/src/methods/FornbergMC.cpp
@@ -419,7 +419,7 @@ void FornbergMC::formSystem()
             Complex denom = z_0 - c_val;
             if (std::abs(denom) < 1e-14)
             {
-                throw std::runtime_error(
+                throw std::invalid_argument(
                     "FornbergMC::formSystem: Inner boundary center c(" + std::to_string(nu_idx) +
                     ") is too close to normalization point z_0. Domain may be degenerate.");
             }

--- a/src/methods/FornbergMC.h
+++ b/src/methods/FornbergMC.h
@@ -63,6 +63,7 @@ class FornbergMC : public ConformalMapMethod
     FRIEND_TEST(FornbergMCFormSystemTest, DimensionsAnnulus);
     FRIEND_TEST(FornbergMCFormSystemTest, DimensionsGeneral);
     FRIEND_TEST(FornbergMCFormSystemTest, NonZeroOutput);
+    FRIEND_TEST(FornbergMCFormSystemTest, ThrowsOnDegenerateDomain);
     FRIEND_TEST(FornbergMCSolveSystemTest, SolutionDimensions);
     FRIEND_TEST(FornbergMCSolveSystemTest, ReducesResidual);
     FRIEND_TEST(FornbergMCSolveSystemTest, ConvergenceInfo);

--- a/tests/fornberg_mc.cpp
+++ b/tests/fornberg_mc.cpp
@@ -392,6 +392,30 @@ TEST_F(FornbergMCFormSystemTest, NonZeroOutput)
     EXPECT_GT(method.getRHSVector().norm(), 0.0);
 }
 
+TEST_F(FornbergMCFormSystemTest, ThrowsOnDegenerateDomain)
+{
+    // Validation for c near z_0 only happens in general (non-annulus) case.
+    // Create a 3-connected domain where one inner boundary center is at z_0 = 0.
+    auto domain = createThreeConnectedDomain();
+
+    FornbergMC method(config);
+
+    method.mp_user_domain = domain;
+    method.m_connectivity = 3;
+    method.m_is_annulus = false;
+
+    // Create canonical domain with one center at z_0 = 0
+    std::vector<Complex> hole_centers = {Complex(0.0, 0.0), Complex(-0.3, 0.0)};
+    std::vector<double> hole_radii = {0.1, 0.12};
+    method.mp_canonical_domain = std::make_shared<FornbergCanonicalDomain>(
+        hole_centers, hole_radii, config.N
+    );
+
+    method.initializeNewtonIteration();
+
+    EXPECT_THROW(method.formSystem(), std::invalid_argument);
+}
+
 // Friend test class for testing private computeFourierCoefficients() method
 class FornbergMCFourierTest : public ::testing::Test
 {


### PR DESCRIPTION
## Summary
- Changed `std::runtime_error` to `std::invalid_argument` for degenerate domain validation in `FornbergMC::formSystem()`
- Added test case to verify the validation throws the correct exception type

## Details

Per CLAUDE.md error handling guidelines: `std::invalid_argument` for validation errors, `std::runtime_error` for runtime failures.

The check validates that inner boundary centers are not at the normalization point z_0 = 0 before computation begins, making it a validation error rather than a runtime failure.

## Test plan
- [x] New test `FornbergMCFormSystemTest.ThrowsOnDegenerateDomain` verifies exception type
- [x] All 165 existing tests pass

Fixes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)