### PR TITLE
GH-56: Narrow catch block in newtonUpdate to runtime_error only

### DIFF
--- a/src/methods/FornbergMC.cpp
+++ b/src/methods/FornbergMC.cpp
@@ -694,8 +694,10 @@ void FornbergMC::newtonUpdate()
         {
             mp_canonical_domain->setConformalModuli(m_conformal_moduli);
         }
-        catch (const std::exception& e)
+        catch (const std::runtime_error& e)
         {
+            // Only catch runtime errors - validation errors (std::invalid_argument)
+            // should propagate as they indicate programming bugs
             // TODO: Replace with spdlog::warn() when logging infrastructure is integrated
             std::cerr << "Warning: Failed to update canonical domain - "
                       << e.what() << ". Keeping current parameters." << std::endl;


### PR DESCRIPTION
## Summary

- Narrow catch block in `FornbergMC::newtonUpdate()` from `std::exception` to `std::runtime_error`
- Validation errors (`std::invalid_argument`) now propagate instead of being suppressed
- Prevents bugs like moduli size mismatches from being masked by warning messages

## Test plan

- [x] All existing tests pass (164/164)
- [x] No new tests needed - this is a fix to error handling behavior

Fixes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)