### PR TITLE
GH-48: Throw exception for non-positive radius in newtonUpdate()

### DIFF
--- a/src/methods/FornbergMC.cpp
+++ b/src/methods/FornbergMC.cpp
@@ -662,9 +662,10 @@ void FornbergMC::newtonUpdate()
         // Validate radius remains positive
         if (std::real(m_conformal_moduli(mod_idx)) <= 0.0)
         {
-            std::cerr << "Warning: Radius for boundary " << (k + 2)
-                      << " became non-positive. Newton iteration may be unstable."
-                      << std::endl;
+            throw std::runtime_error(
+                "FornbergMC::newtonUpdate: Radius for boundary " + std::to_string(k + 2) +
+                " became non-positive (" + std::to_string(std::real(m_conformal_moduli(mod_idx))) +
+                "). Newton iteration has diverged - consider enabling damping or checking domain configuration.");
         }
     }
 

--- a/src/methods/FornbergMC.h
+++ b/src/methods/FornbergMC.h
@@ -73,6 +73,7 @@ class FornbergMC : public ConformalMapMethod
     FRIEND_TEST(FornbergMCNewtonUpdateTest, UpdatesCentersAndRadiiGeneral);
     FRIEND_TEST(FornbergMCNewtonUpdateTest, AppliesDampingWhenEnabled);
     FRIEND_TEST(FornbergMCNewtonUpdateTest, SyncsCanonicalDomain);
+    FRIEND_TEST(FornbergMCNewtonUpdateTest, ThrowsOnNonPositiveRadius);
 #endif
 
 private:

--- a/tests/fornberg_mc.cpp
+++ b/tests/fornberg_mc.cpp
@@ -1126,6 +1126,38 @@ TEST_F(FornbergMCNewtonUpdateTest, SyncsCanonicalDomain)
     }
 }
 
+TEST_F(FornbergMCNewtonUpdateTest, ThrowsOnNonPositiveRadius)
+{
+    // GH-48: Verify that newtonUpdate() throws std::runtime_error when radius becomes non-positive
+    // This is a runtime error condition that prevents correct computation - recovery is not possible
+    auto domain = createAnnulusDomain();
+    FornbergMC method(config);
+
+    method.mp_user_domain = domain;
+    method.m_connectivity = 2;
+    method.m_is_annulus = true;
+    method.mp_canonical_domain = FornbergCanonicalDomain::createFromUserDomain(
+        method.mp_user_domain,
+        FornbergCanonicalDomain::InitialGuessStrategy::GEOMETRIC_CENTROIDS,
+        config.N
+    );
+    method.initializeNewtonIteration();
+    method.formSystem();
+    method.solveSystem();
+
+    const int m = 2;
+    const int N = config.N;
+
+    // Artificially set U to produce a large negative radius update
+    // The initial radius is around 0.1, so a -0.2 update should make it negative
+    double current_radius = std::real(method.m_conformal_moduli(1));
+    double large_negative_update = -(current_radius + 0.1);  // Ensures radius becomes negative
+    method.m_U(m * N) = Complex(large_negative_update, 0.0);
+
+    // newtonUpdate should throw because radius becomes non-positive
+    EXPECT_THROW(method.newtonUpdate(), std::runtime_error);
+}
+
 // GH-45: Newton damping investigation complete
 // Decision: Default to undamped Newton (enable_newton_damping = false) for MATLAB parity in Phase 1.
 // Defer damping as robustness enhancement to Phase 2.


### PR DESCRIPTION
## Summary

Changes the handling of non-positive radius in `newtonUpdate()` from a `std::cerr` warning to throwing `std::runtime_error`.

## Rationale

- A non-positive radius represents a geometrically invalid state where the inner boundary has collapsed or inverted
- Recovery is not possible - subsequent operations would fail anyway (e.g., `formSystem()` divides by `rho_nu`)
- Consistent with existing pattern in `formSystem()` which already throws for `rho <= 0.0`
- Per CLAUDE.md: `std::runtime_error` is appropriate for runtime conditions that prevent correct computation

## Changes

- `FornbergMC.cpp`: Changed `std::cerr` warning to `throw std::runtime_error` with informative message
- `FornbergMC.h`: Added `FRIEND_TEST` declaration for new test
- `fornberg_mc.cpp`: Added test `ThrowsOnNonPositiveRadius`

## Test plan

- [x] All 179 tests pass (1 new test added)
- [x] New test verifies exception is thrown when radius becomes non-positive
- [x] Self-review completed - no issues found

Fixes #48

🤖 Generated with [Claude Code](https://claude.ai/code)