### PR TITLE
GH-50: Add warning for degenerate abs_eta condition in newtonUpdate()

### DIFF
--- a/src/methods/FornbergMC.cpp
+++ b/src/methods/FornbergMC.cpp
@@ -633,8 +633,8 @@ void FornbergMC::newtonUpdate()
             {
                 // TODO: Replace with spdlog warning when logging is integrated
                 std::cerr << "Warning: Degenerate abs_eta detected at boundary " << nu
-                          << ", point " << j << ". Skipping scaling for this point."
-                          << std::endl;
+                          << ", point " << j << " (abs_eta=" << abs_eta_val
+                          << "). Skipping scaling for this point." << std::endl;
             }
         }
     }


### PR DESCRIPTION
## Summary

Adds a warning when `abs_eta_val <= kEpsilon` in `newtonUpdate()`, following the established pattern from `formSystem()`.

## Changes

When the scaling division is skipped due to degenerate `abs_eta`, now logs:
```
Warning: Degenerate abs_eta detected at boundary X, point Y (abs_eta=Z). Skipping scaling for this point.
```

## Pattern Consistency

Matches the existing degenerate tangent warning in `formSystem()`:
```cpp
std::cerr << "Warning: Degenerate tangent detected at boundary " << nu
          << ", point " << j << " (S=" << S_j << "). Using fallback unit tangent."
```

## Test plan

- [x] All 178 tests pass
- [x] Build succeeds with no new warnings
- [x] Self-review completed - added `abs_eta` value to message for debugging parity

Fixes #50

🤖 Generated with [Claude Code](https://claude.ai/code)