### PR TITLE
GH-95: Wire computation progress reporting to GUI via StatusManager

### DIFF
--- a/src/core/StatusManager.cpp
+++ b/src/core/StatusManager.cpp
@@ -247,9 +247,21 @@ void StatusManager::addMessage(const StatusMessage& msg)
         callback_copy = m_statusCallback;
     }
 
-    // Invoke callback outside the lock to avoid deadlock if callback calls back into StatusManager
+    // Invoke callback outside the lock to avoid deadlock if callback calls back into StatusManager.
+    // Wrap in try-catch so a throwing callback cannot crash the caller of reportInfo/reportWarning/etc.
     if (callback_copy)
     {
-        callback_copy(msg);
+        try
+        {
+            callback_copy(msg);
+        }
+        catch (const std::exception& e)
+        {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            if (m_logOutput != LogOutput::NONE && mp_logger)
+            {
+                mp_logger->error("StatusManager callback threw: {}", e.what());
+            }
+        }
     }
 }

--- a/src/core/StatusManager.h
+++ b/src/core/StatusManager.h
@@ -173,6 +173,10 @@ public:
  * This class provides a concrete implementation of the IStatusManager interface,
  * managing status messages with configurable limits and filtering capabilities.
  * Messages are stored in memory with automatic cleanup when limits are exceeded.
+ *
+ * All public methods are thread-safe; concurrent reads and writes are serialized
+ * via an internal mutex. Registered status callbacks are invoked outside the lock
+ * to avoid deadlock when the callback calls back into StatusManager.
  */
 class StatusManager : public IStatusManager
 {
@@ -317,10 +321,12 @@ public:
 
 private:
     /**
-     * @brief Add a message to storage with automatic cleanup
+     * @brief Add a message to storage with automatic cleanup and callback notification
      * @param msg Status message to add
      *
      * If the message count exceeds maxMessages, the oldest message is removed.
+     * If a status callback is registered, it is invoked after releasing the lock.
+     * Callback exceptions are caught and logged, never propagated to the caller.
      */
     void addMessage(const StatusMessage& msg);
 };

--- a/src/gui/GuiController.cpp
+++ b/src/gui/GuiController.cpp
@@ -7,6 +7,7 @@
 #include "../methods/FornbergMC.h"
 #include "../methods/PMatrixBuilder.h"
 #include "../numerics/CGSolver.h"
+#include <sstream>
 
 GuiController::GuiController()
     : mp_currentMap{nullptr}
@@ -220,7 +221,7 @@ void GuiController::computeInBackground()
             method->setCancellationCheck([this]() { return m_cancelRequested.load(); });
         }
 
-        // Downcast for FornbergMC-specific StatusManager and result extraction
+        // Downcast for FornbergMC-specific result extraction and StatusManager access
         auto fm = std::dynamic_pointer_cast<FornbergMC>(method);
 
         // Wire StatusManager callback for live progress updates
@@ -230,30 +231,19 @@ void GuiController::computeInBackground()
             status_manager->setStatusCallback([this](const StatusMessage& msg) {
                 postStatusMessage("[" + msg.component + "] " + msg.message);
 
-                // Parse iteration progress from FornbergMC INFO messages
+                // Parse structured progress data from FornbergMC Newton iteration reports
+                // Details format: "<iteration> <residual>" (machine-readable, set in FornbergMC::compute)
                 if (msg.component == "FornbergMC" && msg.level == StatusLevel::INFO
-                    && msg.message.find("Newton iteration") != std::string::npos)
+                    && !msg.details.empty())
                 {
-                    std::lock_guard<std::mutex> lock(m_progressMutex);
-                    // Parse "Newton iteration N: residual=X"
-                    auto colon_pos = msg.message.find(':');
-                    auto eq_pos = msg.message.find("residual=");
-                    if (colon_pos != std::string::npos)
+                    std::istringstream iss(msg.details);
+                    int iter;
+                    double residual;
+                    if (iss >> iter >> residual)
                     {
-                        try
-                        {
-                            auto iter_str = msg.message.substr(17, colon_pos - 17);
-                            m_liveProgress.currentIteration = std::stoi(iter_str);
-                        }
-                        catch (const std::exception&) {}
-                    }
-                    if (eq_pos != std::string::npos)
-                    {
-                        try
-                        {
-                            m_liveProgress.currentResidual = std::stod(msg.message.substr(eq_pos + 9));
-                        }
-                        catch (const std::exception&) {}
+                        std::lock_guard<std::mutex> lock(m_progressMutex);
+                        m_liveProgress.currentIteration = iter;
+                        m_liveProgress.currentResidual = residual;
                     }
                 }
             });

--- a/src/gui/GuiController.h
+++ b/src/gui/GuiController.h
@@ -48,8 +48,8 @@ private:
     // Live progress from worker thread (protected by m_progressMutex)
     struct ComputationProgress
     {
-        int currentIteration{0};
-        double currentResidual{0.0};
+        int currentIteration{0};    ///< 1-based Newton iteration number (0 = not started)
+        double currentResidual{0.0}; ///< Newton update residual norm
     };
     mutable std::mutex m_progressMutex;
     ComputationProgress m_liveProgress;
@@ -156,8 +156,8 @@ public:
 
     /**
      * @brief Get a snapshot of live computation progress (thread-safe)
-     * @param iteration Output: current iteration number
-     * @param residual Output: current residual value
+     * @param iteration Output: 1-based Newton iteration number (0 if no iteration reported yet)
+     * @param residual Output: current Newton residual (meaningful only when iteration > 0)
      */
     void getLiveProgress(int& iteration, double& residual) const;
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -194,6 +194,12 @@ void MainWindow::renderMainLayout()
 
     if (ImGui::Begin("MainLayout", nullptr, window_flags))
     {
+        // Snapshot live progress once per frame for consistent display
+        if (mp_controller && mp_controller->isComputing())
+        {
+            mp_controller->getLiveProgress(m_cachedLiveIter, m_cachedLiveResidual);
+        }
+
         // Three-panel layout: Control | Visualization | Status
 
         // Control Panel (left column)
@@ -267,14 +273,10 @@ void MainWindow::renderControlPanel()
 
         if (isComputing)
         {
-            int liveIter = 0;
-            double liveResidual = 0.0;
-            mp_controller->getLiveProgress(liveIter, liveResidual);
-
-            if (liveIter > 0)
+            if (m_cachedLiveIter > 0)
             {
-                ImGui::Text("Iteration: %d", liveIter);
-                ImGui::Text("Residual: %.2e", liveResidual);
+                ImGui::Text("Iteration: %d", m_cachedLiveIter);
+                ImGui::Text("Residual: %.2e", m_cachedLiveResidual);
             }
             else
             {
@@ -335,13 +337,10 @@ void MainWindow::renderStatusPanel()
         {
             if (mp_controller->isComputing())
             {
-                int liveIter = 0;
-                double liveResidual = 0.0;
-                mp_controller->getLiveProgress(liveIter, liveResidual);
-                if (liveIter > 0)
+                if (m_cachedLiveIter > 0)
                 {
                     ImGui::SameLine();
-                    ImGui::Text("| Iter: %d | Residual: %.2e", liveIter, liveResidual);
+                    ImGui::Text("| Iter: %d | Residual: %.2e", m_cachedLiveIter, m_cachedLiveResidual);
                 }
             }
             else

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -39,6 +39,10 @@ private:
     bool m_showGrid;
     int m_gridDensity;
 
+    // Cached per-frame live progress (read once in renderMainLayout)
+    int m_cachedLiveIter{0};
+    double m_cachedLiveResidual{0.0};
+
     // Callback for status updates
     void onStatusUpdate(const std::string& message);
     void onComputationComplete();

--- a/src/methods/FornbergMC.cpp
+++ b/src/methods/FornbergMC.cpp
@@ -138,9 +138,11 @@ void FornbergMC::compute(ConformalMap& map_instance, double target_accuracy)
 
         if (mp_status_manager)
         {
-            std::ostringstream oss;
-            oss << "Newton iteration " << (iter + 1) << ": residual=" << m_current_residual;
-            mp_status_manager->reportInfo("FornbergMC", oss.str());
+            std::ostringstream msg;
+            msg << "Newton iteration " << (iter + 1) << ": residual=" << m_current_residual;
+            std::ostringstream det;
+            det << (iter + 1) << " " << m_current_residual;
+            mp_status_manager->reportInfo("FornbergMC", msg.str(), det.str());
         }
 
         // Boundary redistribution if needed

--- a/tests/status_manager_tests.cpp
+++ b/tests/status_manager_tests.cpp
@@ -563,3 +563,63 @@ TEST_F(StatusManagerTest, Callback_ClearedSafely)
     EXPECT_NO_THROW(p_statusManager->reportInfo("Test", "After clear"));
     EXPECT_EQ(callCount, 1);
 }
+
+TEST_F(StatusManagerTest, Callback_ReentrantReportDoesNotDeadlock)
+{
+    int callCount = 0;
+    p_statusManager->setStatusCallback([this, &callCount](const StatusMessage&) {
+        ++callCount;
+        if (callCount == 1)
+        {
+            // Re-enter StatusManager from within callback
+            p_statusManager->reportInfo("Reentrant", "From callback");
+        }
+    });
+
+    p_statusManager->reportInfo("Test", "Trigger");
+
+    EXPECT_EQ(callCount, 2);
+    auto messages = p_statusManager->getMessages();
+    EXPECT_EQ(messages.size(), 2u);
+}
+
+TEST_F(StatusManagerTest, Callback_InvokedConcurrentlyFromMultipleWriters)
+{
+    std::atomic<int> callCount{0};
+    p_statusManager->setStatusCallback([&callCount](const StatusMessage&) {
+        ++callCount;
+    });
+
+    const int num_threads = 4;
+    const int messages_per_thread = 50;
+    std::vector<std::thread> threads;
+    for (int t = 0; t < num_threads; ++t)
+    {
+        threads.emplace_back([this, t, messages_per_thread]() {
+            for (int i = 0; i < messages_per_thread; ++i)
+            {
+                p_statusManager->reportInfo("Thread" + std::to_string(t),
+                                            "Msg " + std::to_string(i));
+            }
+        });
+    }
+
+    for (auto& thread : threads) thread.join();
+
+    EXPECT_EQ(callCount.load(), num_threads * messages_per_thread);
+}
+
+TEST_F(StatusManagerTest, Callback_ExceptionDoesNotCrashCaller)
+{
+    p_statusManager->setStatusCallback([](const StatusMessage&) {
+        throw std::runtime_error("callback error");
+    });
+
+    // reportInfo should not propagate the callback's exception
+    EXPECT_NO_THROW(p_statusManager->reportInfo("Test", "Should not crash"));
+
+    // Message should still be stored despite callback failure
+    auto messages = p_statusManager->getMessages();
+    EXPECT_EQ(messages.size(), 1u);
+    EXPECT_EQ(messages[0].message, "Should not crash");
+}


### PR DESCRIPTION
## Summary
- Wire StatusManager callback to deliver per-iteration progress from FornbergMC worker thread to GUI
- Add thread-safe `StatusCallback` and mutex to `StatusManager` for concurrent access
- Display live iteration count and residual in control panel and status bar during computation
- Per-iteration INFO report in FornbergMC Newton loop feeds StatusManager callback

Replaces PR #98 / #97 (closed due to branch rebases).

Closes #95

## Test plan
- [x] All 258 tests pass
- [x] Thread safety tests: concurrent writes, read-while-writing, callback invocation, callback cleared safely
- [ ] Manual GUI: load example → Compute → verify live iteration/residual updates → Cancel → verify status clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)