### PR TITLE
GH-105: Fix CG solver for high-connectivity convergence

### DIFF
--- a/src/methods/FornbergMCConfiguration.cpp
+++ b/src/methods/FornbergMCConfiguration.cpp
@@ -165,7 +165,7 @@ void FornbergMCConfiguration::setFastComputation()
     newton_tolerance = 1e-8;
     cgm_tolerance = 1e-8;
     max_newton_iterations = 20;
-    max_cgm_iterations = 500;
+    max_cgm_iterations = 20;
     verbose = false;
     boundary_quality_check = false;
 }

--- a/src/methods/FornbergMCConfiguration.h
+++ b/src/methods/FornbergMCConfiguration.h
@@ -33,12 +33,14 @@ struct FornbergMCConfiguration
     bool enable_newton_damping = false;     // MATLAB uses undamped Newton (Phase 1 parity). Consider enabling in Phase 2 for robustness.
     double newton_damping_factor = 0.5;     // Step reduction multiplier when damping enabled
     
-    // Conjugate gradient solver parameters  
+    // Conjugate gradient solver parameters
+    // MATLAB reference (cgm.m) defaults: tol=1e-15, num_iter=20, no restarts.
+    // CG returns best iterate when tolerance isn't met, so short iteration counts work well.
     double cgm_tolerance = 1e-12;           // Relative residual tolerance for CG
-    int max_cgm_iterations = 1000;          // Maximum CG iterations (should scale with N)
+    int max_cgm_iterations = 20;            // Maximum CG iterations per solve (MATLAB default: 20)
     bool enable_best_iterate = true;        // Track best iterate for non-convergent cases
-    double cgm_restart_threshold = 0.1;     // Restart CG if residual stagnates
-    int max_cgm_restarts = 5;               // Maximum CG restarts before giving up (0 disables restarts)
+    double cgm_restart_threshold = 0.1;     // Restart CG if residual stagnates (only used when restarts > 0)
+    int max_cgm_restarts = 0;              // Maximum CG restarts (0 = disabled, matching MATLAB reference)
     
     // Matrix conditioning and stability
     bool monitor_eigenvalues = true;        // Check for nullspace issues

--- a/src/numerics/CGSolver.cpp
+++ b/src/numerics/CGSolver.cpp
@@ -348,6 +348,14 @@ Eigen::VectorXd CGSolver::cgIteration(const MatrixVectorProduct& A_function,
 
 bool CGSolver::shouldRestart(const std::vector<double>& residual_history, int current_iter) const
 {
+    // When restarts are disabled (max_cgm_restarts == 0), never trigger a restart.
+    // MATLAB reference (cgm.m) has no restart mechanism -- it just runs all iterations
+    // and returns the best iterate.
+    if (m_config.max_cgm_restarts == 0)
+    {
+        return false;
+    }
+
     if (current_iter < 10 || residual_history.size() < 10)
     {
         return false; // Too early to judge stagnation


### PR DESCRIPTION
## Summary

- Fix CG solver defaults to match MATLAB reference (`cgm.m`): disable restarts (`max_cgm_restarts=0`) and set `max_cgm_iterations=20`
- The restart mechanism was destroying Krylov subspace information, preventing convergence for the m=7 (6 inner ellipses) thesis example 4
- MATLAB reference uses no restarts -- just 20 CG iterations with best-iterate tracking per Newton step

## Root cause

The CG restart logic triggered every ~12 iterations for the n=914 system (m=7), hitting the max restart count (5) and terminating CG prematurely. Each restart discarded accumulated Krylov subspace info, so the solver could never build enough search directions to make progress. This caused Newton to stagnate at ~3.4e-4 residual.

## Results

| Example | Before | After |
|---------|--------|-------|
| thesis3 (m=4, identity) | 3 iters, converged | 3 iters, converged |
| thesis5 (m=3, ellipses) | 8 iters, converged | 8 iters, converged |
| thesis2 (m=4, mixed) | 22 iters, converged | 22 iters, converged |
| thesis4 (m=7, high connectivity) | **50 iters, STAGNATED at 3.4e-4** | **12 iters, converged** |

All 278 tests pass.

Closes #105

## Test plan

- [x] `./build/conformality_cli --example thesis4` converges (12 iterations, exit code 0)
- [x] All other thesis examples still converge (thesis2, thesis3, thesis5)
- [x] Full test suite passes (278 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)