### PR TITLE
GH-113: Fix test audit findings

### DIFF
--- a/tests/cgsolver.cpp
+++ b/tests/cgsolver.cpp
@@ -572,7 +572,7 @@ TEST_F(CGSolverTest, BreakdownOnNegativeDefiniteSystem)
     const auto& info = solver.getLastConvergenceInfo();
     EXPECT_EQ(info.iterations, 0);
     // Best iterate should be r (residual = b for x0=0), not the zero initial guess.
-    // This verifies the MATLAB cgm.m line 19 fix: x_ = r.
+    // This verifies the MATLAB cgm.m best-iterate initialization fix: x_ = r.
     EXPECT_TRUE(info.used_best_iterate);
     EXPECT_GT(result.norm(), 0.0) << "Breakdown should return residual (r), not zero vector";
     EXPECT_NEAR(result.norm(), b.norm(), 1e-14) << "Best iterate should be b (since x0=0, r=b)";

--- a/tests/fornberg_mc.cpp
+++ b/tests/fornberg_mc.cpp
@@ -319,23 +319,6 @@ TEST_F(FornbergMCTest, FornbergCanonicalDomain)
     EXPECT_THROW(FornbergCanonicalDomain bad_domain(bad_centers, bad_radii, 64), std::invalid_argument);
 }
 
-// Integration test placeholder
-TEST_F(FornbergMCTest, DISABLED_BasicComputeIntegration)
-{
-    // This test is disabled until we have proper multiply connected domains set up
-    // TODO: Implement when domain creation utilities are available
-
-    FornbergMC method(config);
-
-    // Create source and target domains
-    // auto source_domain = createCanonicalDomain();
-    // auto target_domain = createTestMultiplyConnectedDomain();
-    //
-    // ConformalMap map(source_domain, target_domain);
-    //
-    // EXPECT_NO_THROW(method.compute(map));
-}
-
 // Convergence history test
 TEST_F(FornbergMCTest, ConvergenceTracking)
 {

--- a/tests/pmatrixbuilder.cpp
+++ b/tests/pmatrixbuilder.cpp
@@ -408,7 +408,7 @@ TEST_F(PMatrixBuilderTest, FrequencyIndicesFFTWOrder)
     }
 
     // Critical test: Nyquist frequency at index N/2 should be -N/2, not N/2
-    // This is the bug from issue #34
+    // This was the bug from issue #34
     EXPECT_EQ(freq_indices[config.N / 2], -config.N / 2)
         << "Nyquist frequency at index N/2=" << config.N / 2
         << " should be -N/2=" << -config.N / 2 << ", not N/2";


### PR DESCRIPTION
## Summary
- Removed `DISABLED_BasicComputeIntegration` test (disabled tests still compile per project convention)
- Fixed MATLAB line number reference in cgsolver.cpp comment to use descriptive text instead
- Fixed regression comment tense in pmatrixbuilder.cpp ("is" -> "was")

Full audit of 20 test files (278+ tests) found only these 3 minor style issues.

## Test plan
- [x] All 306 tests pass after removing disabled test
- [x] No other disabled tests remain

Fixes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)