### PR TITLE
GH-126: Move MethodInfo utilities into conformality namespace

### DIFF
--- a/src/core/MethodInfo.h
+++ b/src/core/MethodInfo.h
@@ -24,6 +24,9 @@
 #include <variant>
 #include <vector>
 
+namespace conformality
+{
+
 using MethodInfoValue = std::variant<int, double, bool, std::string>;
 
 struct MethodInfoField
@@ -39,15 +42,22 @@ struct MethodInfo
     std::vector<MethodInfoField> results;
 };
 
+namespace detail
+{
+
 template <class... Ts>
 struct overloaded : Ts... { using Ts::operator()...; };
 
+} // namespace detail
+
 inline std::string formatMethodInfoValue(const MethodInfoValue& value)
 {
-    return std::visit(overloaded{
+    return std::visit(detail::overloaded{
         [](int v) { return std::to_string(v); },
         [](double v) { std::ostringstream s; s << std::scientific << std::setprecision(2) << v; return s.str(); },
         [](bool v) -> std::string { return v ? "Yes" : "No"; },
         [](const std::string& v) { return v; }
     }, value);
 }
+
+} // namespace conformality

--- a/src/gui/GuiController.h
+++ b/src/gui/GuiController.h
@@ -62,7 +62,7 @@ private:
     std::string m_lastErrorMessage;
     int m_lastIterationCount{0};
     bool m_hasConverged{false};
-    MethodInfo m_lastMethodInfo;
+    conformality::MethodInfo m_lastMethodInfo;
 
     // Callbacks for GUI updates (only called from main/GUI thread)
     std::function<void()> m_onComputationComplete;
@@ -202,9 +202,9 @@ public:
 
     /**
      * @brief Get method info from last computation
-     * @return MethodInfo with parameters and results
+     * @return conformality::MethodInfo with parameters and results
      */
-    const MethodInfo& getLastMethodInfo() const { return m_lastMethodInfo; }
+    const conformality::MethodInfo& getLastMethodInfo() const { return m_lastMethodInfo; }
 
     /**
      * @brief Set callback for computation completion

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -6,6 +6,8 @@
 #include "imgui.h"
 #include "implot.h"
 
+using conformality::formatMethodInfoValue;
+
 MainWindow::MainWindow()
     : m_showDemoWindow{false}
     , m_showAboutDialog{false}

--- a/src/methods/ConformalMapMethod.h
+++ b/src/methods/ConformalMapMethod.h
@@ -135,9 +135,9 @@ public:
 
     /**
      * @brief Get a descriptor with method name, parameters, and results
-     * @return MethodInfo populated by the concrete method (empty by default)
+     * @return conformality::MethodInfo populated by the concrete method (empty by default)
      */
-    virtual MethodInfo getMethodInfo() const { return {}; }
+    virtual conformality::MethodInfo getMethodInfo() const { return {}; }
 
     /**
      * @brief Set a cancellation check callback for cooperative cancellation

--- a/src/methods/FornbergMC.cpp
+++ b/src/methods/FornbergMC.cpp
@@ -29,9 +29,9 @@
 #include <cmath>
 #include <algorithm>
 
-MethodInfo FornbergMC::getMethodInfo() const
+conformality::MethodInfo FornbergMC::getMethodInfo() const
 {
-    MethodInfo info;
+    conformality::MethodInfo info;
     info.name = "FornbergMC";
 
     info.parameters = {

--- a/src/methods/FornbergMC.h
+++ b/src/methods/FornbergMC.h
@@ -187,7 +187,7 @@ public:
      */
     Complex inverseMap(const Complex& w) const override;
 
-    MethodInfo getMethodInfo() const override;
+    conformality::MethodInfo getMethodInfo() const override;
 
     /**
      * @brief Get the current configuration

--- a/tests/method_info_tests.cpp
+++ b/tests/method_info_tests.cpp
@@ -24,6 +24,10 @@
 #include "../src/methods/PMatrixBuilder.h"
 #include "../src/numerics/CGSolver.h"
 
+using conformality::formatMethodInfoValue;
+using conformality::MethodInfo;
+using conformality::MethodInfoValue;
+
 // ---------- Base class default ----------
 
 TEST(MethodInfoBaseClassTest, ReturnsEmpty)


### PR DESCRIPTION
## Summary

- Wraps `MethodInfoValue`, `MethodInfoField`, `MethodInfo`, and `formatMethodInfoValue` in the `conformality` namespace inside `src/core/MethodInfo.h`
- Places the `overloaded` std::visit helper in `conformality::detail` to keep it out of the public API
- Qualifies all consumer sites: `ConformalMapMethod.h`, `FornbergMC.h`, `FornbergMC.cpp`, `GuiController.h`, `MainWindow.cpp`, and `tests/method_info_tests.cpp`

Fixes #126

## Test plan

- [ ] Build succeeds in Release mode: `cmake -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build -j$(nproc)`
- [ ] All tests pass: `ctest --test-dir build`
- [ ] `method_info_tests` specifically passes with no regressions
- [ ] No global-namespace `MethodInfo*`, `overloaded`, or `formatMethodInfoValue` symbols remain (confirmed via grep)

Generated with Claude Code