### PR TITLE
GH-123: Cache DR/DI in FornbergMC to avoid per-iteration matrix copies

### DIFF
--- a/src/methods/FornbergMC.cpp
+++ b/src/methods/FornbergMC.cpp
@@ -719,6 +719,11 @@ void FornbergMC::formSystem()
         constexpr double norm_value = 0.0;  // norm_cond(3) = 0
         mp_matrix_builder->applyNormalizationConditions(m_D, m_g, norm_value);
     }
+
+    // Cache real/imaginary parts of m_D for use in solveSystem().
+    // Avoids repeated full-matrix copies on every Newton iteration.
+    m_DR = m_D.real();
+    m_DI = m_D.imag();
 }
 
 void FornbergMC::solveSystem()
@@ -747,10 +752,9 @@ void FornbergMC::solveSystem()
     Eigen::VectorXd b = (2.0 / N) * (m_D.adjoint() * m_g).real();
 
     // Matrix-vector product: A*x = 2*(DR'*(DR*x) + DI'*(DI*x))/N
-    Eigen::MatrixXd DR = m_D.real();
-    Eigen::MatrixXd DI = m_D.imag();
-    auto A_function = [&DR, &DI, N](const Eigen::VectorXd& x) -> Eigen::VectorXd {
-        return (2.0 / N) * (DR.transpose() * (DR * x) + DI.transpose() * (DI * x));
+    // m_DR and m_DI are cached in formSystem() and reused across Newton iterations.
+    auto A_function = [this, N](const Eigen::VectorXd& x) -> Eigen::VectorXd {
+        return (2.0 / N) * (m_DR.transpose() * (m_DR * x) + m_DI.transpose() * (m_DI * x));
     };
 
     // Solve the real system directly

--- a/src/methods/FornbergMC.h
+++ b/src/methods/FornbergMC.h
@@ -133,6 +133,8 @@ private:
 
     // Linear system components
     Eigen::MatrixXcd m_D;                   // System matrix
+    Eigen::MatrixXd m_DR;                   // Cached real part of m_D (updated in formSystem())
+    Eigen::MatrixXd m_DI;                   // Cached imaginary part of m_D (updated in formSystem())
     Eigen::VectorXcd m_g;                   // RHS vector
     Eigen::VectorXcd m_U;                   // Solution vector (complex to match D*U=g)
 


### PR DESCRIPTION
## Summary

- Add `m_DR` and `m_DI` (`Eigen::MatrixXd`) as member variables to `FornbergMC` (FornbergMC.h)
- Populate them once at the end of `formSystem()`, after `m_D` is fully built (including normalization rows)
- Update `solveSystem()` to use the cached members via `this` capture in the `A_function` lambda instead of constructing local copies each call

## Motivation

Previously, `solveSystem()` called `m_D.real()` and `m_D.imag()` on every Newton iteration, each materializing a full `Eigen::MatrixXd` copy. For thesis2 (N=256), `m_D` is ~514×1033 complex — roughly two 16 MB allocations (plus copy cost) per iteration. Since `m_D` only changes between Newton iterations (set in `formSystem()`), caching these splits is free after the first `formSystem()` call.

## Notes

- Stacked on `gh-121-formsystem-fft-optimization` (GH-121). This PR's base branch is `gh-121-formsystem-fft-optimization` and should be merged after that PR lands.
- 306/306 tests pass.

Fixes #123

Generated with Claude Code