### PR TITLE
GH-40: Centralize and document epsilon/tolerance constants

### DIFF
--- a/src/core/Tolerances.h
+++ b/src/core/Tolerances.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2025, Everett Kropf (ehkropf@gmail.com)
+ *
+ * This file is part of Conformality.
+ * Conformality is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * Conformality is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along
+ * with Conformality. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <limits>
+
+/*
+ * Centralized numerical tolerances for near-zero checks and division guards.
+ *
+ * Rationale (see also .claude/references/conformality/tolerances.md):
+ *
+ * All domains handled by the solver are normalized to the unit disk, so
+ * coordinates and the quantities derived from them have O(1) magnitude. With
+ * O(1) operands, ABSOLUTE tolerances scaled near machine epsilon (1e-14, 1e-15)
+ * are the appropriate choice for geometric-coincidence and pivot guards;
+ * converting them to relative tolerances buys nothing and risks regressing the
+ * validated thesis-example convergence (thesis2 / thesis4 / thesis5).
+ *
+ * The one intentionally RELATIVE tolerance is SPLINE_CLOSURE_EPS, because it
+ * compares user-supplied input points that are NOT yet normalized, so it is
+ * scaled by machine epsilon rather than fixed.
+ *
+ * Constants are grouped by MEANING, not by value: several share a numeric value
+ * today but guard distinct conditions, and should be tuned independently.
+ *
+ * Do NOT retune any of these without re-running the thesis regression tests --
+ * a change in their numerical output indicates the tolerance mattered.
+ *
+ * Related: BOUNDARY_TOLERANCE (1e-12) in Types.h is the domain-containment
+ * tolerance and lives there with the other domain-level definitions.
+ */
+
+/// Two points/centers are treated as coincident, or a complex magnitude treated
+/// as zero, on the unit-disk-normalized domain (Laurent-series denominators,
+/// hole-center coincidence, Sherman-Morrison singularity).
+constexpr double GEOMETRIC_COINCIDENCE_EPS = 1e-14;
+
+/// Guards the relative-update scaling in the Fornberg radius (Newton) update.
+/// Distinct in meaning from GEOMETRIC_COINCIDENCE_EPS even though equal today:
+/// it scales an update, it does not test coincidence.
+constexpr double NEWTON_UPDATE_SCALE_EPS = 1e-14;
+
+/// Pivot / segment-length / derivative guards that protect a division
+/// (ray-cast segment height, spline chord and tridiagonal pivots, Newton
+/// derivative breakdown).
+constexpr double PIVOT_EPS = 1e-15;
+
+/// Endpoint-coincidence (closed-curve) test on raw, un-normalized user input.
+/// Intentionally RELATIVE: scaled by machine epsilon rather than a fixed value.
+constexpr double SPLINE_CLOSURE_EPS = 100.0 * std::numeric_limits<double>::epsilon();
+
+/// Grid geometry on the unit-disk-scaled domain: degenerate-radius clamp,
+/// full-circle detection, and point deduplication.
+constexpr double GRID_GEOMETRY_EPS = 1e-10;
+
+/// Step size for central/forward finite-difference derivatives and normals
+/// (a deliberate ~sqrt(machine epsilon) choice).
+constexpr double FINITE_DIFFERENCE_STEP = 1e-6;

--- a/src/core/Tolerances.h
+++ b/src/core/Tolerances.h
@@ -51,9 +51,10 @@
 /// hole-center coincidence, Sherman-Morrison singularity).
 constexpr double GEOMETRIC_COINCIDENCE_EPS = 1e-14;
 
-/// Guards the relative-update scaling in the Fornberg radius (Newton) update.
-/// Distinct in meaning from GEOMETRIC_COINCIDENCE_EPS even though equal today:
-/// it scales an update, it does not test coincidence.
+/// Guards the per-point tangent-magnitude divisor in the Fornberg radius
+/// (Newton) update. Distinct in meaning from GEOMETRIC_COINCIDENCE_EPS even
+/// though equal today: it guards a different physical quantity (the update
+/// scaling), and the two should be tuned independently.
 constexpr double NEWTON_UPDATE_SCALE_EPS = 1e-14;
 
 /// Pivot / segment-length / derivative guards that protect a division

--- a/src/domains/BoundaryComponent.cpp
+++ b/src/domains/BoundaryComponent.cpp
@@ -18,6 +18,7 @@
 
 #include "BoundaryComponent.h"
 #include "../numerics/RootFinder.h"
+#include "../core/Tolerances.h"
 
 #include <cmath>
 #include <stdexcept>
@@ -127,7 +128,7 @@ Complex DiscreteBoundaryComponent::evaluateDerivative(double t) const
 {
     // TODO: Check if we need anything more complicated than simple finite difference.
     // Simple finite difference approximation
-    const double h = 1e-6;
+    const double h = FINITE_DIFFERENCE_STEP;
     Complex fwd = evaluate(t + h);
     Complex bwd = evaluate(t - h);
     Complex diff = fwd - bwd;

--- a/src/domains/Domain.cpp
+++ b/src/domains/Domain.cpp
@@ -18,6 +18,7 @@
 
 #include "Domain.h"
 #include "../core/Types.h"
+#include "../core/Tolerances.h"
 #include <limits>
 #include <algorithm>
 #include <cmath>
@@ -57,7 +58,7 @@ int Domain::calculateWindingNumber(const Complex& z, const std::vector<Complex>&
             (imag(p2) <= imag(z) && imag(p1) > imag(z)))
         {
             // Avoid division by zero
-            if (std::abs(imag(p2) - imag(p1)) < 1e-15)
+            if (std::abs(imag(p2) - imag(p1)) < PIVOT_EPS)
             {
                 continue;
             }
@@ -91,7 +92,7 @@ double Domain::distanceToLineSegment(const Complex& point, const Complex& segmen
 
     // If segment has zero length, return distance to start point
     double segmentLengthSq = std::norm(v);
-    if (segmentLengthSq < 1e-15)
+    if (segmentLengthSq < PIVOT_EPS)
     {
         return std::abs(point - segmentStart);
     }
@@ -209,7 +210,7 @@ std::shared_ptr<Boundary> StarlikeDomain::createBoundary(
         double r = radiusFunc(t);
 
         // Approximate r'(θ) with finite difference
-        const double h = 1e-6;
+        const double h = FINITE_DIFFERENCE_STEP;
         double rPrime = (radiusFunc(t + h) - radiusFunc(t - h)) / (2.0 * h);
 
         Complex tangent = Complex(rPrime * std::cos(t), rPrime * std::sin(t)) +

--- a/src/domains/SplineBoundaryComponent.cpp
+++ b/src/domains/SplineBoundaryComponent.cpp
@@ -18,6 +18,7 @@
 
 #include "SplineBoundaryComponent.h"
 #include "../numerics/RootFinder.h"
+#include "../core/Tolerances.h"
 
 #include <algorithm>
 #include <cmath>
@@ -45,8 +46,8 @@ SplineBoundaryComponent::SplineBoundaryComponent(
     {
         int npts = static_cast<int>(px.size());
         // Ensure closure before counting segments
-        bool is_closed = (std::abs(px.front() - px.back()) <= 100.0 * std::numeric_limits<double>::epsilon()
-                       && std::abs(py.front() - py.back()) <= 100.0 * std::numeric_limits<double>::epsilon());
+        bool is_closed = (std::abs(px.front() - px.back()) <= SPLINE_CLOSURE_EPS
+                       && std::abs(py.front() - py.back()) <= SPLINE_CLOSURE_EPS);
         int num_segments = is_closed ? npts - 1 : npts;
         int nn = refinement_N / num_segments;
         if (nn > 0)
@@ -186,8 +187,8 @@ SplineBoundaryComponent::computePeriodicSplineCoefficients(
     std::vector<double> y = y_in;
 
     // Ensure closure
-    if (std::abs(x.front() - x.back()) > 100.0 * std::numeric_limits<double>::epsilon()
-        || std::abs(y.front() - y.back()) > 100.0 * std::numeric_limits<double>::epsilon())
+    if (std::abs(x.front() - x.back()) > SPLINE_CLOSURE_EPS
+        || std::abs(y.front() - y.back()) > SPLINE_CLOSURE_EPS)
     {
         x.push_back(x.front());
         y.push_back(y.front());
@@ -208,7 +209,7 @@ SplineBoundaryComponent::computePeriodicSplineCoefficients(
     // Validate no zero-length segments (prevents division by zero in coefficient computation)
     for (int i = 0; i < n; ++i)
     {
-        if (h[i] < 1e-15)
+        if (h[i] < PIVOT_EPS)
         {
             throw std::invalid_argument(
                 "SplineBoundaryComponent: zero-length chord at segment " + std::to_string(i)
@@ -320,8 +321,8 @@ SplineBoundaryComponent::upsampleControlPoints(
     std::vector<double> y = y_in;
 
     // Ensure closure
-    if (std::abs(x.front() - x.back()) > 100.0 * std::numeric_limits<double>::epsilon()
-        || std::abs(y.front() - y.back()) > 100.0 * std::numeric_limits<double>::epsilon())
+    if (std::abs(x.front() - x.back()) > SPLINE_CLOSURE_EPS
+        || std::abs(y.front() - y.back()) > SPLINE_CLOSURE_EPS)
     {
         x.push_back(x.front());
         y.push_back(y.front());
@@ -398,7 +399,7 @@ std::vector<double> SplineBoundaryComponent::solveTridiagonal(
     // Forward sweep
     for (int i = 1; i < n; ++i)
     {
-        if (std::abs(b[i - 1]) < 1e-15)
+        if (std::abs(b[i - 1]) < PIVOT_EPS)
         {
             throw std::runtime_error(
                 "SplineBoundaryComponent: tridiagonal solver encountered zero pivot at index "
@@ -410,7 +411,7 @@ std::vector<double> SplineBoundaryComponent::solveTridiagonal(
     }
     // Back substitution
     std::vector<double> x(n);
-    if (std::abs(b[n - 1]) < 1e-15)
+    if (std::abs(b[n - 1]) < PIVOT_EPS)
     {
         throw std::runtime_error(
             "SplineBoundaryComponent: tridiagonal solver encountered zero pivot at index "
@@ -475,7 +476,7 @@ std::vector<double> SplineBoundaryComponent::solvePeriodicTridiagonal(
     }
 
     double denom = 1.0 + vTz;
-    if (std::abs(denom) < 1e-14)
+    if (std::abs(denom) < GEOMETRIC_COINCIDENCE_EPS)
     {
         throw std::runtime_error(
             "SplineBoundaryComponent: periodic tridiagonal system is singular "

--- a/src/methods/FornbergMC.cpp
+++ b/src/methods/FornbergMC.cpp
@@ -23,6 +23,7 @@
 #include "../numerics/FFTWWrapper.h"
 #include "../domains/FornbergCanonicalDomain.h"
 #include "../core/ConformalMap.h"
+#include "../core/Tolerances.h"
 #include "../domains/Domain.h"
 #include <sstream>
 #include <stdexcept>
@@ -275,7 +276,7 @@ Complex FornbergMC::map(const Complex& z) const
             const Complex z_minus_c = z - c_nu;
 
             // Check for singularity at hole center
-            if (std::abs(z_minus_c) < 1e-14)
+            if (std::abs(z_minus_c) < GEOMETRIC_COINCIDENCE_EPS)
             {
                 throw std::runtime_error("FornbergMC: Evaluation point too close to hole center");
             }
@@ -520,7 +521,7 @@ void FornbergMC::formSystem()
             Complex tangent = boundaries[nu]->evaluateDerivative(S_j);
             double abs_t = std::abs(tangent);
             m_abs_eta(j, nu) = abs_t;
-            if (abs_t > 1e-14)
+            if (abs_t > GEOMETRIC_COINCIDENCE_EPS)
             {
                 eta(j, nu) = tangent / abs_t;
             }
@@ -574,7 +575,7 @@ void FornbergMC::formSystem()
 
             // Validate that inner boundary center is not at normalization point
             Complex denom = z_0 - c_val;
-            if (std::abs(denom) < 1e-14)
+            if (std::abs(denom) < GEOMETRIC_COINCIDENCE_EPS)
             {
                 throw std::invalid_argument(
                     "FornbergMC::formSystem: Inner boundary center c(" + std::to_string(nu_idx) +
@@ -779,13 +780,12 @@ void FornbergMC::newtonUpdate()
     const int N = m_config.N;
 
     // Step 1: Scale boundary updates by 1/abs_eta (matches MATLAB: U(1:m*N)./abs_eta(:))
-    constexpr double kEpsilon = 1e-14;
     for (int nu = 0; nu < m; ++nu)
     {
         for (int j = 0; j < N; ++j)
         {
             double abs_eta_val = m_abs_eta(j, nu);
-            if (abs_eta_val > kEpsilon)
+            if (abs_eta_val > NEWTON_UPDATE_SCALE_EPS)
             {
                 m_U(nu * N + j) /= abs_eta_val;
             }

--- a/src/methods/PMatrixBuilder.cpp
+++ b/src/methods/PMatrixBuilder.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "PMatrixBuilder.h"
+#include "../core/Tolerances.h"
 #include <stdexcept>
 
 PMatrixBuilder::PMatrixBuilder(const FornbergMCConfiguration& config, int connectivity, bool is_annulus)
@@ -311,12 +312,12 @@ Eigen::MatrixXcd PMatrixBuilder::buildGeneralPMatrix(int nu, const ConformalModu
             std::complex<double> c_diff = c_nu - c_L;
 
             // Validate that hole centers are not coincident
-            if (std::abs(c_diff) < 1e-14)
+            if (std::abs(c_diff) < GEOMETRIC_COINCIDENCE_EPS)
             {
                 throw std::invalid_argument(
                     "PMatrixBuilder::buildGeneralPMatrix: Inner boundary centers c(" + std::to_string(nu - 1) +
                     ") and c(" + std::to_string(L) + ") are too close (distance " +
-                    std::to_string(std::abs(c_diff)) + " < 1e-14). " +
+                    std::to_string(std::abs(c_diff)) + " below coincidence tolerance). " +
                     "Ensure circle centers are distinct. Domain may be degenerate.");
             }
             std::complex<double> pl_cvl = rho_L / c_diff;
@@ -441,12 +442,12 @@ Eigen::MatrixXcd PMatrixBuilder::buildAnnulusPMatrix(int nu, const ConformalModu
             std::complex<double> c_diff = c_nu - c_L;
 
             // Validate that hole centers are not coincident
-            if (std::abs(c_diff) < 1e-14)
+            if (std::abs(c_diff) < GEOMETRIC_COINCIDENCE_EPS)
             {
                 throw std::invalid_argument(
                     "PMatrixBuilder::buildAnnulusPMatrix: Inner boundary centers c(" + std::to_string(nu - 1) +
                     ") and c(" + std::to_string(L) + ") are too close (distance " +
-                    std::to_string(std::abs(c_diff)) + " < 1e-14). " +
+                    std::to_string(std::abs(c_diff)) + " below coincidence tolerance). " +
                     "Ensure circle centers are distinct. Domain may be degenerate.");
             }
             std::complex<double> pl_cvl = rho_L / c_diff;
@@ -511,12 +512,12 @@ Eigen::MatrixXcd PMatrixBuilder::buildAnnulusPMatrix(int nu, const ConformalModu
             std::complex<double> c_diff = c_nu - c_L;
 
             // Validate that hole centers are not coincident (higher inner boundaries)
-            if (std::abs(c_diff) < 1e-14)
+            if (std::abs(c_diff) < GEOMETRIC_COINCIDENCE_EPS)
             {
                 throw std::invalid_argument(
                     "PMatrixBuilder::buildAnnulusPMatrix: Inner boundary centers c(" + std::to_string(nu - 1) +
                     ") and c(" + std::to_string(L) + ") are too close (distance " +
-                    std::to_string(std::abs(c_diff)) + " < 1e-14). " +
+                    std::to_string(std::abs(c_diff)) + " below coincidence tolerance). " +
                     "Ensure circle centers are distinct. Domain may be degenerate.");
             }
             std::complex<double> pl_cvl = rho_L / c_diff;

--- a/src/numerics/Grid.cpp
+++ b/src/numerics/Grid.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "Grid.h"
+#include "../core/Tolerances.h"
 #include <cmath>
 #include <stdexcept>
 #include <algorithm>
@@ -152,7 +153,7 @@ void Grid::generatePolarGrid()
                 {
                     continue;
                 }
-                r = std::min(r, 1e-10); // Avoid exact zero to prevent degenerate point
+                r = std::min(r, GRID_GEOMETRY_EPS); // Avoid exact zero to prevent degenerate point
             }
 
             Complex point = std::polar(r, angle);
@@ -179,7 +180,7 @@ void Grid::generatePolarGrid()
         for (int i = 0; i <= numRadialLines; ++i)
         {
             double angle = angleMin + i * (angleMax - angleMin) / numRadialLines;
-            if (i == numRadialLines && std::abs(angleMax - angleMin - 2.0 * M_PI) < 1e-10)
+            if (i == numRadialLines && std::abs(angleMax - angleMin - 2.0 * M_PI) < GRID_GEOMETRY_EPS)
             {
                 // Skip the last point if it overlaps with the first for a full circle
                 break;
@@ -195,7 +196,7 @@ void Grid::generatePolarGrid()
             // Check if this point already exists in the grid
             auto it = std::find_if(points.begin(), points.end(), [&point](const Complex& p)
             {
-                return std::abs(point - p) < 1e-10;
+                return std::abs(point - p) < GRID_GEOMETRY_EPS;
             });
 
             if (it != points.end())

--- a/src/numerics/RootFinder.h
+++ b/src/numerics/RootFinder.h
@@ -23,6 +23,8 @@
 #include <stdexcept>
 #include <complex>
 
+#include "../core/Tolerances.h"
+
 /**
  * @brief Utility class for root finding and optimization algorithms
  */
@@ -96,7 +98,7 @@ T RootFinder::newton(std::function<T(T)> function,
             return x;
         }
 
-        if (std::abs(dfx) < 1e-15)
+        if (std::abs(dfx) < PIVOT_EPS)
         {
             throw ConvergenceError("Newton's method: derivative too small");
         }

--- a/tests/pmatrixbuilder.cpp
+++ b/tests/pmatrixbuilder.cpp
@@ -611,7 +611,8 @@ TEST_F(PMatrixBuilderTest, CoincidentCircleErrorMessageIncludesDiagnostics)
     {
         std::string msg = e.what();
         EXPECT_NE(msg.find("distance"), std::string::npos) << "Error message should include 'distance'";
-        EXPECT_NE(msg.find("1e-14"), std::string::npos) << "Error message should include threshold '1e-14'";
+        EXPECT_NE(msg.find("coincidence tolerance"), std::string::npos)
+            << "Error message should reference the coincidence tolerance";
         EXPECT_NE(msg.find("Ensure circle centers are distinct"), std::string::npos)
             << "Error message should include actionable guidance";
     }


### PR DESCRIPTION
Closes #40 (centralization scope; hazard guards split to #144).

## Context

Issue #40 asked for a codebase-wide review of epsilon selection and scaling. An audit found its original trigger — a `rho_val / (z_0 - c_val)` division — was **already guarded**, and that the real problem was consistency: the codebase had exactly **one** centralized tolerance (`BOUNDARY_TOLERANCE` in `Types.h`) and **15+ scattered, undocumented magic numbers** (`1e-14`, `1e-15`, `1e-10`, `1e-6`, `100·ε`).

Per discussion, the work was split along its risk boundary into two issues. **This PR is the value-preserving half**; the genuine behavior-changing hazard guards are tracked in **#144**.

## What this PR does

1. **Adds `src/core/Tolerances.h`** — named `constexpr` constants grouped by *meaning* (not value), with a rationale comment block: domains are unit-disk-normalized, so O(1) operands make **absolute** machine-epsilon-scaled tolerances appropriate; `SPLINE_CLOSURE_EPS` is intentionally **relative** because it compares un-normalized user input. Includes a 'do not retune without re-running thesis regression tests' warning.
   - `GEOMETRIC_COINCIDENCE_EPS` (1e-14), `NEWTON_UPDATE_SCALE_EPS` (1e-14), `PIVOT_EPS` (1e-15), `SPLINE_CLOSURE_EPS` (100·ε, relative), `GRID_GEOMETRY_EPS` (1e-10), `FINITE_DIFFERENCE_STEP` (1e-6).
2. **Replaces the scattered literals** across FornbergMC, PMatrixBuilder, Domain, SplineBoundaryComponent, RootFinder, and Grid with these constants. **Every value is byte-identical** → no behavior change.
3. The PMatrixBuilder coincident-center error message no longer hardcodes `1e-14` (which would drift from the constant); it reports the actual distance and references the coincidence tolerance. Its test assertion is updated to match.

`BOUNDARY_TOLERANCE` stays in `Types.h` (domain-level), cross-referenced from the new header. `FornbergMCConfiguration` tolerances are left as-is (already named and configurable).

## Verification

- Release build clean (2 pre-existing unused-parameter warnings only).
- `ctest`: **306/306 pass**, including the thesis examples (thesis2/thesis4/thesis5) — the regression guardrail for the value-preserving claim.

## Out of scope (tracked elsewhere)
- Grid single-line division-by-zero + RootFinder NaN/inf guards → **#144**.
- AnalyticBoundaryComponent atan2 fallback, CGSolver restart-division guards, any absolute→relative retuning → noted in #144 as their own follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)