### PR TITLE
GH-144: Guard genuine division/NaN hazards surfaced by the #40 epsilon audit

### DIFF
--- a/src/numerics/Grid.cpp
+++ b/src/numerics/Grid.cpp
@@ -53,6 +53,16 @@ Grid::Grid(GridType gridType)
     regenerate();
 }
 
+void Grid::validateLineCount(const char* name, int value)
+{
+    if (value < 2)
+    {
+        throw std::invalid_argument(std::string("Grid line count '") + name +
+                                    "' must be at least 2 (got " + std::to_string(value) +
+                                    "); single-line grids are degenerate and divide by zero.");
+    }
+}
+
 Grid Grid::createPolarGrid(
     int numRadial,
     int numAngular,
@@ -62,6 +72,9 @@ Grid Grid::createPolarGrid(
     double aMaximum,
     bool includeOriginPoint)
 {
+    validateLineCount("numRadial", numRadial);
+    validateLineCount("numAngular", numAngular);
+
     Grid grid(GridType::POLAR);
 
     grid.numRadialLines = numRadial;
@@ -84,6 +97,9 @@ Grid Grid::createCartesianGrid(
     double yMinimum,
     double yMaximum)
 {
+    validateLineCount("numHorizontal", numHorizontal);
+    validateLineCount("numVertical", numVertical);
+
     Grid grid(GridType::CARTESIAN);
 
     grid.numHorizontalLines = numHorizontal;
@@ -106,6 +122,9 @@ Grid Grid::createParametricGrid(
     double vMinimum,
     double vMaximum)
 {
+    validateLineCount("numUlines", numUlines);
+    validateLineCount("numVlines", numVlines);
+
     Grid grid(GridType::PARAMETRIC);
 
     grid.parameterization = paramFunc;
@@ -447,8 +466,8 @@ bool Grid::setParameter(const std::string& name, double value)
             else if (name == "rMax") { rMax = value; return true; }
             else if (name == "angleMin") { angleMin = value; return true; }
             else if (name == "angleMax") { angleMax = value; return true; }
-            else if (name == "numRadialLines") { numRadialLines = static_cast<int>(value); return true; }
-            else if (name == "numAngularLines") { numAngularLines = static_cast<int>(value); return true; }
+            else if (name == "numRadialLines") { validateLineCount("numRadialLines", static_cast<int>(value)); numRadialLines = static_cast<int>(value); return true; }
+            else if (name == "numAngularLines") { validateLineCount("numAngularLines", static_cast<int>(value)); numAngularLines = static_cast<int>(value); return true; }
             else if (name == "includeOrigin") { includeOrigin = value != 0.0; return true; }
             break;
 
@@ -457,8 +476,8 @@ bool Grid::setParameter(const std::string& name, double value)
             else if (name == "xMax") { xMax = value; return true; }
             else if (name == "yMin") { yMin = value; return true; }
             else if (name == "yMax") { yMax = value; return true; }
-            else if (name == "numHorizontalLines") { numHorizontalLines = static_cast<int>(value); return true; }
-            else if (name == "numVerticalLines") { numVerticalLines = static_cast<int>(value); return true; }
+            else if (name == "numHorizontalLines") { validateLineCount("numHorizontalLines", static_cast<int>(value)); numHorizontalLines = static_cast<int>(value); return true; }
+            else if (name == "numVerticalLines") { validateLineCount("numVerticalLines", static_cast<int>(value)); numVerticalLines = static_cast<int>(value); return true; }
             break;
 
         case GridType::PARAMETRIC:
@@ -466,8 +485,8 @@ bool Grid::setParameter(const std::string& name, double value)
             else if (name == "uMax") { uMax = value; return true; }
             else if (name == "vMin") { vMin = value; return true; }
             else if (name == "vMax") { vMax = value; return true; }
-            else if (name == "numULines") { numULines = static_cast<int>(value); return true; }
-            else if (name == "numVLines") { numVLines = static_cast<int>(value); return true; }
+            else if (name == "numULines") { validateLineCount("numULines", static_cast<int>(value)); numULines = static_cast<int>(value); return true; }
+            else if (name == "numVLines") { validateLineCount("numVLines", static_cast<int>(value)); numVLines = static_cast<int>(value); return true; }
             break;
     }
 

--- a/src/numerics/Grid.h
+++ b/src/numerics/Grid.h
@@ -66,6 +66,18 @@ private:
     int numULines, numVLines;          // Parametric grid line counts
 
     /**
+     * @brief Validate a grid line count, rejecting degenerate single-line grids
+     *
+     * Grid spacing is computed as (max - min) / (count - 1), so a count of 1 divides
+     * by zero (producing NaN), and a count below 2 is degenerate for visualization.
+     *
+     * @param name Parameter name, used in the error message
+     * @param value Requested line count
+     * @throws std::invalid_argument if value < 2
+     */
+    static void validateLineCount(const char* name, int value);
+
+    /**
      * @brief Generate a polar grid
      */
     void generatePolarGrid();

--- a/src/numerics/Grid.h
+++ b/src/numerics/Grid.h
@@ -66,10 +66,11 @@ private:
     int numULines, numVLines;          // Parametric grid line counts
 
     /**
-     * @brief Validate a grid line count, rejecting degenerate single-line grids
+     * @brief Validate a grid line count, rejecting degenerate (< 2) line counts
      *
-     * Grid spacing is computed as (max - min) / (count - 1), so a count of 1 divides
-     * by zero (producing NaN), and a count below 2 is degenerate for visualization.
+     * Most grid spacings are computed as (max - min) / (count - 1), so a count of 1
+     * divides by zero (producing NaN); counts of 0 or fewer are likewise degenerate.
+     * Requiring at least 2 lines keeps every divided axis well-defined.
      *
      * @param name Parameter name, used in the error message
      * @param value Requested line count
@@ -219,6 +220,7 @@ public:
      * @param name Parameter name
      * @param value Parameter value
      * @return bool True if parameter was set, false if name was not recognized
+     * @throws std::invalid_argument if a line-count parameter is set below 2
      */
     bool setParameter(const std::string& name, double value);
 

--- a/src/numerics/RootFinder.cpp
+++ b/src/numerics/RootFinder.cpp
@@ -46,6 +46,11 @@ double RootFinder::ternarySearch(std::function<double(double)> objective,
         double f1 = objective(mid1);
         double f2 = objective(mid2);
 
+        if (!std::isfinite(f1) || !std::isfinite(f2))
+        {
+            throw ConvergenceError("Ternary search: non-finite objective value");
+        }
+
         if (f1 > f2)
         {
             low = mid1;

--- a/src/numerics/RootFinder.h
+++ b/src/numerics/RootFinder.h
@@ -93,6 +93,13 @@ T RootFinder::newton(std::function<T(T)> function,
         T fx = function(x);
         T dfx = derivative(x);
 
+        // std::abs of a std::complex yields a real magnitude, so this guard works for
+        // both the real and complex template instantiations.
+        if (!std::isfinite(std::abs(fx)) || !std::isfinite(std::abs(dfx)))
+        {
+            throw ConvergenceError("Newton's method: non-finite function or derivative value");
+        }
+
         if (std::abs(fx) < tolerance)
         {
             return x;

--- a/tests/grids.cpp
+++ b/tests/grids.cpp
@@ -19,6 +19,7 @@
 #include <gtest/gtest.h>
 #include "../src/numerics/Grid.h"
 #include <cmath>
+#include <stdexcept>
 
 // Helper function to compare complex points
 bool pointsEqual(const Complex& a, const Complex& b, double tolerance = 1e-10)
@@ -361,4 +362,44 @@ TEST(GridTest, Regeneration)
     // Number of lines should be 12 radial + (6-1) angular = 17 total
     // (One angular line is skipped because it would be degenerate at r=0)
     EXPECT_EQ(17, grid.getLineCount());
+}
+
+// Regression tests for GH-144: grid spacing is computed as (max - min) / (count - 1),
+// so a line count of 1 divided 0.0/0.0 -> NaN and silently poisoned the grid before the
+// guard. Each factory now rejects counts below 2 on every divided axis.
+TEST(GridTest, PolarGridRejectsSingleLine)
+{
+    EXPECT_THROW(Grid::createPolarGrid(1, 4), std::invalid_argument);
+    EXPECT_THROW(Grid::createPolarGrid(8, 1), std::invalid_argument);
+    // The minimum valid count (2) on each axis is accepted.
+    EXPECT_NO_THROW(Grid::createPolarGrid(2, 2));
+}
+
+TEST(GridTest, CartesianGridRejectsSingleLine)
+{
+    EXPECT_THROW(Grid::createCartesianGrid(1, 5), std::invalid_argument);
+    EXPECT_THROW(Grid::createCartesianGrid(5, 1), std::invalid_argument);
+    EXPECT_NO_THROW(Grid::createCartesianGrid(2, 2));
+}
+
+TEST(GridTest, ParametricGridRejectsSingleLine)
+{
+    auto identity = [](double u, double v) -> Complex { return Complex(u, v); };
+    EXPECT_THROW(Grid::createParametricGrid(identity, 1, 4), std::invalid_argument);
+    EXPECT_THROW(Grid::createParametricGrid(identity, 4, 1), std::invalid_argument);
+    EXPECT_NO_THROW(Grid::createParametricGrid(identity, 2, 2));
+}
+
+TEST(GridTest, SetParameterRejectsSingleLineCount)
+{
+    // setParameter + regenerate reached the same division as the factories, so the
+    // count keys are guarded here too.
+    Grid grid = Grid::createPolarGrid(8, 4);
+    EXPECT_THROW(grid.setParameter("numAngularLines", 1.0), std::invalid_argument);
+    EXPECT_THROW(grid.setParameter("numRadialLines", 1.0), std::invalid_argument);
+    EXPECT_NO_THROW(grid.setParameter("numAngularLines", 2.0));
+
+    Grid cartesian = Grid::createCartesianGrid(5, 5);
+    EXPECT_THROW(cartesian.setParameter("numHorizontalLines", 1.0), std::invalid_argument);
+    EXPECT_THROW(cartesian.setParameter("numVerticalLines", 1.0), std::invalid_argument);
 }

--- a/tests/grids.cpp
+++ b/tests/grids.cpp
@@ -402,4 +402,10 @@ TEST(GridTest, SetParameterRejectsSingleLineCount)
     Grid cartesian = Grid::createCartesianGrid(5, 5);
     EXPECT_THROW(cartesian.setParameter("numHorizontalLines", 1.0), std::invalid_argument);
     EXPECT_THROW(cartesian.setParameter("numVerticalLines", 1.0), std::invalid_argument);
+
+    // Each else-if is an independent call site, so the parametric keys are covered too.
+    auto identity = [](double u, double v) -> Complex { return Complex(u, v); };
+    Grid parametric = Grid::createParametricGrid(identity, 4, 4);
+    EXPECT_THROW(parametric.setParameter("numULines", 1.0), std::invalid_argument);
+    EXPECT_THROW(parametric.setParameter("numVLines", 1.0), std::invalid_argument);
 }

--- a/tests/root_finder_tests.cpp
+++ b/tests/root_finder_tests.cpp
@@ -230,6 +230,10 @@ TEST(RootFinderTest, NewtonRejectsNonFiniteDerivative)
         return std::numeric_limits<double>::infinity();
     };
 
+    // Distinct failure mode from the NaN case: an infinite derivative made fx/dfx
+    // collapse to 0, so without the guard newton silently returned the initial guess
+    // as a "root" rather than spinning to maxIterations. A plain EXPECT_THROW catches
+    // this regression directly.
     EXPECT_THROW(RootFinder::newton<double>(function, derivative, 1.0),
                  RootFinder::ConvergenceError);
 }

--- a/tests/root_finder_tests.cpp
+++ b/tests/root_finder_tests.cpp
@@ -19,6 +19,8 @@
 #include <gtest/gtest.h>
 #include <cmath>
 #include <complex>
+#include <limits>
+#include <string>
 #include "../src/numerics/RootFinder.h"
 
 TEST(RootFinderTest, TernarySearchQuadratic)
@@ -196,4 +198,65 @@ TEST(RootFinderTest, NewtonMethodConvergenceToZero)
 
     double result = RootFinder::newton<double>(function, derivative, 1.5);
     EXPECT_NEAR(1.0, result, 1e-3); // Slower convergence for multiple roots
+}
+
+// Regression tests for GH-144: newton and ternarySearch had no finiteness guards, so a
+// NaN/inf evaluation silently spun Newton to maxIterations or made ternary search return
+// a meaningless midpoint. They now throw ConvergenceError on the first non-finite value.
+TEST(RootFinderTest, NewtonRejectsNonFiniteFunction)
+{
+    auto function = [](double) -> double { return std::nan(""); };
+    auto derivative = [](double) -> double { return 1.0; };
+
+    // Without the guard a NaN function value still throws ConvergenceError, but only
+    // after spinning to maxIterations; assert the fast-fail message so this test
+    // verifies the guard rather than the max-iteration fallback.
+    try
+    {
+        RootFinder::newton<double>(function, derivative, 1.0);
+        FAIL() << "expected ConvergenceError for non-finite function value";
+    }
+    catch (const RootFinder::ConvergenceError& e)
+    {
+        EXPECT_NE(std::string(e.what()).find("non-finite"), std::string::npos);
+    }
+}
+
+TEST(RootFinderTest, NewtonRejectsNonFiniteDerivative)
+{
+    auto function = [](double x) -> double { return x; };
+    auto derivative = [](double) -> double
+    {
+        return std::numeric_limits<double>::infinity();
+    };
+
+    EXPECT_THROW(RootFinder::newton<double>(function, derivative, 1.0),
+                 RootFinder::ConvergenceError);
+}
+
+TEST(RootFinderTest, NewtonRejectsNonFiniteComplexValue)
+{
+    // std::abs of a std::complex yields a real magnitude, so the guard fires for the
+    // complex instantiation too.
+    using Cplx = std::complex<double>;
+    auto function = [](Cplx) -> Cplx { return Cplx(std::nan(""), 0.0); };
+    auto derivative = [](Cplx) -> Cplx { return Cplx(1.0, 0.0); };
+
+    try
+    {
+        RootFinder::newton<Cplx>(function, derivative, Cplx(1.0, 1.0));
+        FAIL() << "expected ConvergenceError for non-finite complex value";
+    }
+    catch (const RootFinder::ConvergenceError& e)
+    {
+        EXPECT_NE(std::string(e.what()).find("non-finite"), std::string::npos);
+    }
+}
+
+TEST(RootFinderTest, TernarySearchRejectsNonFiniteObjective)
+{
+    auto objective = [](double) -> double { return std::nan(""); };
+
+    EXPECT_THROW(RootFinder::ternarySearch(objective, 0.0, 4.0),
+                 RootFinder::ConvergenceError);
 }


### PR DESCRIPTION
Fixes #144. Depends on #40 (merged in #145).

The #40 epsilon-selection audit surfaced two genuine, currently **unguarded numerical hazards** (distinct from #40, which centralized tolerance constants without changing behavior). This PR adds the guards + tests.

## 1. Grid factories divide by zero for single-line grids

Grid spacing is `(max - min) / (count - 1)`, so a line count of 1 computes `0.0 / 0.0` → **NaN**, silently poisoning the whole grid.

- New `Grid::validateLineCount(name, value)` helper throws `std::invalid_argument` for counts `< 2`.
- Wired into all three factories (`createPolarGrid`, `createCartesianGrid`, `createParametricGrid`) on every divided axis.
- Also wired into `setParameter()` for all six count keys — that path reaches the same division via `regenerate()`, so guarding only the factories would leave a hole (per review decision).
- Decision: **reject** single-line grids, do not special-case. Hard floor is `>= 2` (the true div-by-zero floor); counts 2..9 still compute fine and stay allowed.

## 2. RootFinder has no NaN/inf guards

`newton` and `ternarySearch` never checked `std::isfinite`, so a NaN spun Newton to `maxIterations` (then threw the *wrong* `ConvergenceError`) and ternary search returned a meaningless midpoint.

- `newton` (`RootFinder.h`) and `ternarySearch` (`RootFinder.cpp`) now throw `ConvergenceError` on the first non-finite evaluation.
- `std::abs` of a `std::complex` yields a real magnitude, so the Newton guard covers both the `double` and complex instantiations.

## Tests

- `GridTest`: each factory with a count of 1 on each axis → `std::invalid_argument`; count of 2 succeeds; `setParameter` count of 1 → throws.
- `RootFinderTest`: NaN/inf callables (real + complex) → `ConvergenceError`. The Newton NaN tests assert the fast-fail *message* to distinguish the new guard from the pre-existing max-iteration fallback (both throw `ConvergenceError`, so `EXPECT_THROW` alone wouldn't verify the guard).
- Regression-verified by reverting each guard and confirming the new tests fail, then restoring.

**314/314 tests pass** on the real `/opt/local` toolchain (Release).

## Out of scope (own issues if pursued, per #144)

- `AnalyticBoundaryComponent::findParameterization` atan2 fallback bug.
- `CGSolver` unguarded `beta = rsnew/rsold` / restart improvement-rate divisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)